### PR TITLE
Provide configuration for reaching API under different environments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ testem.log
 bower.json.ember-try
 package.json.ember-try
 .envrc
+.env

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ $ cd GoodForPoc
 $ npm install --global ember-cli # If you don't have Ember installed already.
 $ npm install --global bower     # If you don't have Bower installed already.
 $ npm install                    # Fetch dependencies.
+$ bower install                  # Grab more dependencies.
+$ touch .env
+```
+
+Open that `.env` file and put the following in there:
+```sh
+G4POC_API_ENDPOINT=http://localhost:9292/
+```
+
+Then run:
+
+```sh
 $ npm start
 ```
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -23,7 +23,9 @@ module.exports = function(environment) {
       'img-src': "data: app.getsentry.com",
       'connect-src': "'self' localhost",
     },
-    APP: {},
+    APP: {
+      apiEndpoint: process.env.G4POC_API_ENDPOINT,
+    },
     segment: {
       WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
       LOG_EVENT_TRACKING: ''

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,7 +7,8 @@ module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     dotEnv: {
       clientAllowedKeys: [
-        'SEGMENT_WRITE_KEY'
+        'SEGMENT_WRITE_KEY',
+        'G4POC_API_ENDPOINT',
       ]
     }
     // Add options here


### PR DESCRIPTION
## Feature idea 

This'll allow developers that plan to interact with the API for GoodForPoc to do so in a fashion that's transparent to them.

### Tasks

- [x] Add to `config/environment.js` a value that can determine the hostname of the API depending on the test environment it's in.
- [ ] Create a means for reaching the staging environment when under test mode but also when either `API_USE_STAGING` or `CI` are set.
- [ ] Add a test to confirm environment switches are properly detected.

## Reviewers
@GoodForPoC/owners
